### PR TITLE
Update repository url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 description = "Trait for real and complex numbers"
 documentation = "https://docs.rs/cauchy"
-repository = "https://github.com/termoshtt/cauchy"
+repository = "https://github.com/rust-math/cauchy"
 keywords = []
 categories = ["algorithms"]
 license = "MIT"


### PR DESCRIPTION
The old one redirects to the new one, but still better to stay up-to-date.